### PR TITLE
fix: custom kube config

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -17,9 +17,21 @@ limitations under the License.
 package options
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	diskcached "k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 )
+
+const MaxInFlightDefault = 25
 
 type KetallOptions struct {
 	UseCache        bool     `json:"useCache,omitempty"`
@@ -51,8 +63,48 @@ func (t *KetAllConfigFlags) ToRESTConfig() (*rest.Config, error) {
 	return t.ConfigFlags.ToRESTConfig()
 }
 
+func (t *KetAllConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
+	if t.KubeConfig != nil {
+		discoveryClient, err := t.ToDiscoveryClient()
+		if err != nil {
+			return nil, err
+		}
+
+		mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+		expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
+		return expander, nil
+	}
+
+	return t.ConfigFlags.ToRESTMapper()
+}
+
+func (t *KetAllConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	if t.KubeConfig != nil {
+		config := t.KubeConfig
+		cacheDir := os.TempDir()
+		httpCacheDir := filepath.Join(cacheDir, "http")
+		discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
+		return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(6*time.Hour))
+	}
+
+	return t.ConfigFlags.ToDiscoveryClient()
+}
+
+// overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive
+var overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/.)]`)
+
+// computeDiscoverCacheDir takes the parentDir and the host and comes up with a "usually non-colliding" name.
+func computeDiscoverCacheDir(parentDir, host string) string {
+	// strip the optional scheme from host if its there:
+	schemelessHost := strings.Replace(strings.Replace(host, "https://", "", 1), "http://", "", 1)
+	// now do a simple collapse of non-AZ09 characters.  Collisions are possible but unlikely.  Even if we do collide the problem is short lived
+	safeHost := overlyCautiousIllegalFileCharacters.ReplaceAllString(schemelessHost, "_")
+	return filepath.Join(parentDir, safeHost)
+}
+
 func NewDefaultCmdOptions() *KetallOptions {
 	return &KetallOptions{
+		MaxInflight: MaxInFlightDefault,
 		Flags: &KetAllConfigFlags{
 			ConfigFlags: genericclioptions.NewConfigFlags(true),
 		},

--- a/options/options.go
+++ b/options/options.go
@@ -90,6 +90,9 @@ func (t *KetAllConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterf
 	return t.ConfigFlags.ToDiscoveryClient()
 }
 
+// Copyright 2018 The Kubernetes Authors.
+// k8s.io/cli-runtime@v0.28.0/pkg/genericclioptions/config_flags.go
+
 // overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive
 var overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/.)]`)
 


### PR DESCRIPTION
* When a custom config was passed, it wasn't used in the discovery client and as a restmapper
* fix deadlock by setting a default value for maxinflight

resolves: https://github.com/flanksource/config-db/issues/479